### PR TITLE
reorganize project to be more general

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -24,7 +24,7 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/karasz/gomesh/peers"
+	"github.com/karasz/gomesh/wireguard"
 	"github.com/spf13/cobra"
 )
 
@@ -51,7 +51,7 @@ var addCmd = &cobra.Command{
 		postup, _ := cmd.Flags().GetString("postup")
 		postdown, _ := cmd.Flags().GetString("postdown")
 		saveconfig, _ := cmd.Flags().GetBool("saveconfig")
-		p := peers.Peer{Name: name, PrivateKey: privatekey, Address: address, ListenPort: listenport, Endpoint: endpoint, AllowedIPs: allowedips, FwMark: fwmark, DNS: dns, MTU: mtu, Table: table, PreUp: preup, PostUp: postup, PreDown: predown, PostDown: postdown, SaveConfig: saveconfig}
+		p := wireguard.Peer{Name: name, PrivateKey: privatekey, Address: address, ListenPort: listenport, Endpoint: endpoint, AllowedIPs: allowedips, FwMark: fwmark, DNS: dns, MTU: mtu, Table: table, PreUp: preup, PostUp: postup, PreDown: predown, PostDown: postdown, SaveConfig: saveconfig}
 		err := thePeers.AddPeer(p)
 		return err
 	},

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -27,10 +27,10 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/karasz/gomesh/peers"
+	"github.com/karasz/gomesh/wireguard"
 )
 
-var thePeers peers.Peers
+var thePeers wireguard.Peers
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
@@ -56,7 +56,7 @@ func init() {
 
 func initDatabase(filePath string) {
 	var err error
-	thePeers, err = peers.LoadPeers(filePath)
+	thePeers, err = wireguard.LoadPeers(filePath)
 
 	if err != nil {
 		fmt.Println(err)

--- a/wireguard/keys.go
+++ b/wireguard/keys.go
@@ -19,7 +19,8 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
-package keys
+
+package wireguard
 
 import (
 	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"

--- a/wireguard/peers.go
+++ b/wireguard/peers.go
@@ -19,7 +19,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
-package peers
+package wireguard
 
 import (
 	"encoding/json"
@@ -29,8 +29,6 @@ import (
 	"strconv"
 	"strings"
 	"text/tabwriter"
-
-	"github.com/karasz/gomesh/keys"
 )
 
 // Peers is a map containing all
@@ -97,7 +95,7 @@ func (p Peers) peerExists(pr Peer) bool {
 //AddPeer will add a Peer to the register
 func (p Peers) AddPeer(pr Peer) error {
 	if pr.PrivateKey == "" {
-		k, err := keys.GenerateKey()
+		k, err := GenerateKey()
 		if err != nil {
 			return err
 		}
@@ -165,7 +163,7 @@ func (p Peers) dumpConfig(pr Peer, folder string, id int) error {
 		if p[j].Name != pr.Name {
 			strToWrite = strToWrite + "\n[Peer]\n"
 			strToWrite = strToWrite + fmt.Sprintf("# Name: %s\n", strings.ToLower(p[j].Name))
-			pub, err := keys.PublicKey(p[j].PrivateKey)
+			pub, err := PublicKey(p[j].PrivateKey)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
This will unify the wireguard peers and keys management in an unified wireguard module paving the road for maybe teaching gomesh to work with multiple configuration file types.